### PR TITLE
#6: added migration to PHP7.2 and simple docker-compose setup. Migrated to phpunit 7 and 8.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 composer.lock
 vendor
 data/*.php
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: php
 php:
-  - 5.6
-  - 7.0
   - 7.1
+  - 7.2
 before_script:
   - composer self-update
   - composer install

--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,8 @@
     "minimum-stability": "dev",
     "require": {
         "mikey179/vfsStream": "1.6.*",
-        "mockery/mockery": "0.9.*",
-        "php": ">=5.3.3",
-        "phpunit/phpunit": "~4.8||~5.2",
+        "php": ">=7.1",
+        "phpunit/phpunit": "^7.0|^8.0",
         "propel/propel1": "~1.6"
     },
     "license": "LGPL-3.0",
@@ -46,5 +45,8 @@
         "classmap": [
             "source/"
         ]
+    },
+    "require-dev": {
+        "symplify/easy-coding-standard": "^6.1@dev"
     }
 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,13 @@
+version: '3'
+services:
+  php:
+    image: thecodingmachine/php:7.2-v2-cli
+    tty: true
+    command: bash
+    working_dir: /usr/src/app
+    volumes:
+      - .:/usr/src/app
+    environment:
+      - PHP_EXTENSION_INTL=1
+      - PHP_EXTENSION_PDO_SQLITE=1
+      - STARTUP_COMMAND_1=composer install

--- a/source/AbstractEntity.php
+++ b/source/AbstractEntity.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Net\Bazzline\Propel\Behavior\EntityInstantiator;
 
 /**

--- a/source/AddToEntityInstantiatorBehavior.php
+++ b/source/AddToEntityInstantiatorBehavior.php
@@ -1,19 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 use Net\Bazzline\Propel\Behavior\EntityInstantiator\Manager;
 use Net\Bazzline\Propel\Behavior\EntityInstantiator\ObjectEntity;
 use Net\Bazzline\Propel\Behavior\EntityInstantiator\QueryEntity;
 
-//@todo do we need this if dependencies are managed via composer and composer autoloader?
-$pathToClasses = __DIR__ . '/';
-
-require_once($pathToClasses . 'AbstractEntity.php');
-require_once($pathToClasses . 'Configuration.php');
-require_once($pathToClasses . 'EntityCollection.php');
-require_once($pathToClasses . 'FileContentGenerator.php');
-require_once($pathToClasses . 'Manager.php');
-require_once($pathToClasses . 'ObjectEntity.php');
-require_once($pathToClasses . 'QueryEntity.php');
 
 /**
  * @author stev leibelt <artodeto@bazzline.net>
@@ -22,16 +14,16 @@ require_once($pathToClasses . 'QueryEntity.php');
  */
 class AddToEntityInstantiatorBehavior extends Behavior
 {
-    const PARAMETER_ENTITY_INSTANTIATOR_ADD_IT_TO_ENTITY_INSTANTIATOR   = 'entity_instantiator_add_to_entity_instantiator';
-    const PARAMETER_ENTITY_INSTANTIATOR_DEFAULT_CONNECTION_MODE         = 'entity_instantiator_default_connection_mode';
-    const PARAMETER_ENTITY_INSTANTIATOR_DEFAULT_CONNECTION_NAME         = 'entity_instantiator_default_connection_name';
-    const PARAMETER_ENTITY_INSTANTIATOR_CLASS_NAME                      = 'entity_instantiator_class_name';
-    const PARAMETER_ENTITY_INSTANTIATOR_EXTENDS                         = 'entity_instantiator_extends';
-    const PARAMETER_ENTITY_INSTANTIATOR_INDENTION                       = 'entity_instantiator_indention';
-    const PARAMETER_ENTITY_INSTANTIATOR_METHOD_NAME_PREFIX              = 'entity_instantiator_method_name_prefix';
-    const PARAMETER_ENTITY_INSTANTIATOR_NAMESPACE                       = 'entity_instantiator_namespace';
-    const PARAMETER_ENTITY_INSTANTIATOR_PATH_TO_OUTPUT                  = 'entity_instantiator_path_to_output';
-    const PARAMETER_ENTITY_INSTANTIATOR_USE_FULLY_QUALIFIED_NAME        = 'entity_instantiator_use_fully_qualified_name';
+    public const PARAMETER_ENTITY_INSTANTIATOR_ADD_IT_TO_ENTITY_INSTANTIATOR   = 'entity_instantiator_add_to_entity_instantiator';
+    public const PARAMETER_ENTITY_INSTANTIATOR_DEFAULT_CONNECTION_MODE         = 'entity_instantiator_default_connection_mode';
+    public const PARAMETER_ENTITY_INSTANTIATOR_DEFAULT_CONNECTION_NAME         = 'entity_instantiator_default_connection_name';
+    public const PARAMETER_ENTITY_INSTANTIATOR_CLASS_NAME                      = 'entity_instantiator_class_name';
+    public const PARAMETER_ENTITY_INSTANTIATOR_EXTENDS                         = 'entity_instantiator_extends';
+    public const PARAMETER_ENTITY_INSTANTIATOR_INDENTION                       = 'entity_instantiator_indention';
+    public const PARAMETER_ENTITY_INSTANTIATOR_METHOD_NAME_PREFIX              = 'entity_instantiator_method_name_prefix';
+    public const PARAMETER_ENTITY_INSTANTIATOR_NAMESPACE                       = 'entity_instantiator_namespace';
+    public const PARAMETER_ENTITY_INSTANTIATOR_PATH_TO_OUTPUT                  = 'entity_instantiator_path_to_output';
+    public const PARAMETER_ENTITY_INSTANTIATOR_USE_FULLY_QUALIFIED_NAME        = 'entity_instantiator_use_fully_qualified_name';
 
     /** @var array */
     protected $parameters = [
@@ -82,7 +74,7 @@ class AddToEntityInstantiatorBehavior extends Behavior
      */
     public function addObjectToGenerator(
         DataModelBuilder $builder
-    ) {
+    ): void {
         if ($this->addIt()) {
             $manager    = $this->getManager();
             $entity     = $this->buildEntityFromObject($builder);
@@ -96,7 +88,7 @@ class AddToEntityInstantiatorBehavior extends Behavior
      */
     public function addQueryToGenerator(
         DataModelBuilder $builder
-    ) {
+    ): void {
         if ($this->addIt()) {
             $manager    = $this->getManager();
             $entity     = $this->buildEntityFromQuery($builder);

--- a/source/Configuration.php
+++ b/source/Configuration.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @author stev leibelt <artodeto@bazzline.net>
  * @since 2015-09-19
@@ -56,7 +59,7 @@ class Configuration
         $defaultConnectionMode = null,
         $defaultConnectionName = null,
         $useFullyQualifiedNames = null
-    ) {
+    ): void {
         $this->setClassName($className);
 
         if (!is_null($extends)) {
@@ -198,7 +201,7 @@ class Configuration
      * @param string $className
      * @throws InvalidArgumentException
      */
-    private function setClassName($className)
+    private function setClassName($className): void
     {
         $this->throwInvalidArgumentExceptionIfStringIsNotValid($className);
         $this->className = $className;
@@ -208,7 +211,7 @@ class Configuration
      * @param string $defaultConnectionMode
      * @throws InvalidArgumentException
      */
-    private function setDefaultConnectionMode($defaultConnectionMode)
+    private function setDefaultConnectionMode($defaultConnectionMode): void
     {
         $this->throwInvalidArgumentExceptionIfStringIsNotValid($defaultConnectionMode);
         $this->defaultConnectionMode = $defaultConnectionMode;
@@ -218,7 +221,7 @@ class Configuration
      * @param string $defaultConnectionName
      * @throws InvalidArgumentException
      */
-    private function setDefaultConnectionName($defaultConnectionName)
+    private function setDefaultConnectionName($defaultConnectionName): void
     {
         $this->throwInvalidArgumentExceptionIfStringIsNotValid($defaultConnectionName);
         $this->defaultConnectionName = $defaultConnectionName;
@@ -228,7 +231,7 @@ class Configuration
      * @param string $extends
      * @throws InvalidArgumentException
      */
-    private function setExtends($extends)
+    private function setExtends($extends): void
     {
         $this->throwInvalidArgumentExceptionIfStringIsNotValid($extends);
         $this->extends = $extends;
@@ -238,7 +241,7 @@ class Configuration
      * @param string $indention
      * @throws InvalidArgumentException
      */
-    private function setIndention($indention)
+    private function setIndention($indention): void
     {
         $this->throwInvalidArgumentExceptionIfStringIsNotValid($indention);
         $this->indention = $indention;
@@ -248,7 +251,7 @@ class Configuration
      * @param string $namespace
      * @throws InvalidArgumentException
      */
-    private function setNamespace($namespace)
+    private function setNamespace($namespace): void
     {
         $this->throwInvalidArgumentExceptionIfStringIsNotValid($namespace);
         $this->namespace = $namespace;
@@ -258,7 +261,7 @@ class Configuration
      * @param $useFullyQualifiedName
      * @throws InvalidArgumentException
      */
-    private function setUseFullyQualifiedName($useFullyQualifiedName)
+    private function setUseFullyQualifiedName($useFullyQualifiedName): void
     {
         if (!is_bool($useFullyQualifiedName)) {
             throw new InvalidArgumentException(
@@ -272,7 +275,7 @@ class Configuration
      * @param string $string
      * @throws InvalidArgumentException
      */
-    private function throwInvalidArgumentExceptionIfStringIsNotValid($string)
+    private function throwInvalidArgumentExceptionIfStringIsNotValid($string): void
     {
         if (!is_string($string)) {
             throw new InvalidArgumentException(
@@ -291,7 +294,7 @@ class Configuration
      * @param string $path
      * @throws InvalidArgumentException
      */
-    private function tryToCreatePathNameToFileOutputOrThrowInvalidArgumentException($path)
+    private function tryToCreatePathNameToFileOutputOrThrowInvalidArgumentException($path): void
     {
         if (!is_dir($path)) {
             throw new InvalidArgumentException(

--- a/source/EntityCollection.php
+++ b/source/EntityCollection.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @author stev leibelt <artodeto@bazzline.net>
  * @since 2015-08-29
@@ -30,7 +33,7 @@ class EntityCollection implements ArrayAccess, Countable, Iterator
      */
     public function add(
         AbstractEntity $entity
-    ) {
+    ): void {
         $this->throwInvalidArgumentExceptionIfEntityWasAlreadyAdded($entity);
         $this->entityCollection[] = $entity;
     }
@@ -41,7 +44,7 @@ class EntityCollection implements ArrayAccess, Countable, Iterator
      */
     private function throwInvalidArgumentExceptionIfEntityWasAlreadyAdded(
         AbstractEntity $entity
-    ) {
+    ): void {
         $hash = sha1($entity->databaseName() . '_' . $entity->className());
 
         if (isset($this->hashCollection[$hash])) {
@@ -100,7 +103,7 @@ class EntityCollection implements ArrayAccess, Countable, Iterator
      * @return void
      * @since 5.0.0
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->entityCollection[] = $value;
@@ -118,7 +121,7 @@ class EntityCollection implements ArrayAccess, Countable, Iterator
      * @return void
      * @since 5.0.0
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->entityCollection[$offset]);
     }
@@ -159,7 +162,7 @@ class EntityCollection implements ArrayAccess, Countable, Iterator
      * @return void Any returned value is ignored.
      * @since 5.0.0
      */
-    public function next()
+    public function next(): void
     {
         next($this->entityCollection);
     }
@@ -193,7 +196,7 @@ class EntityCollection implements ArrayAccess, Countable, Iterator
      * @return void Any returned value is ignored.
      * @since 5.0.0
      */
-    public function rewind()
+    public function rewind(): void
     {
         reset($this->entityCollection);
     }

--- a/source/FileContentGenerator.php
+++ b/source/FileContentGenerator.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @author stev leibelt <artodeto@bazzline.net>
  * @since 2015-09-19

--- a/source/Manager.php
+++ b/source/Manager.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Net\Bazzline\Propel\Behavior\EntityInstantiator;
 
 use InvalidArgumentException;
@@ -51,7 +53,7 @@ class Manager
      * @param AbstractEntity $entity
      * @throws InvalidArgumentException
      */
-    public function add(AbstractEntity $entity)
+    public function add(AbstractEntity $entity): void
     {
         $this->collection->add($entity);
     }
@@ -76,7 +78,7 @@ class Manager
         $defaultConnectionMode = null,
         $defaultConnectionName = null,
         $useFullyQualifiedNames = null
-    ) {
+    ): void {
         $this->configuration->configure(
             $className,
             $indention,
@@ -92,7 +94,7 @@ class Manager
     /**
      * @throws RuntimeException
      */
-    public function generate()
+    public function generate(): void
     {
         //begin of dependencies
         $configuration  = $this->configuration;
@@ -121,7 +123,7 @@ class Manager
         return $this->configuration->isNotConfigured();
     }
 
-    public function reset()
+    public function reset(): void
     {
         $this->collection       = new EntityCollection();
         $this->configuration    = new Configuration();
@@ -136,7 +138,7 @@ class Manager
      * @param string $content
      * @throws RuntimeException
      */
-    private function tryToWriteContentOrThrowRuntimeException($fileName, $content)
+    private function tryToWriteContentOrThrowRuntimeException($fileName, $content): void
     {
         $contentCouldBeNotWritten = (file_put_contents($fileName, $content) === false);
 
@@ -167,7 +169,7 @@ class Manager
     /**
      * @throws RuntimeException
      */
-    private function throwRuntimeExceptionIfConfigurationIsNotDone()
+    private function throwRuntimeExceptionIfConfigurationIsNotDone(): void
     {
         if ($this->isNotConfigured()) {
             throw new RuntimeException(

--- a/source/ObjectEntity.php
+++ b/source/ObjectEntity.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @author stev leibelt <artodeto@bazzline.net>
  * @since 2015-08-30

--- a/source/QueryEntity.php
+++ b/source/QueryEntity.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @author stev leibelt <artodeto@bazzline.net>
  * @since 2015-08-30

--- a/test/AddToEntityInstantiatorBehaviorWithMaximumConfigurationTest.php
+++ b/test/AddToEntityInstantiatorBehaviorWithMaximumConfigurationTest.php
@@ -1,12 +1,16 @@
 <?php
+
+declare(strict_types=1);
+
 use Net\Bazzline\Propel\Behavior\EntityInstantiator\Manager;
 use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author stev leibelt <artodeto@bazzline.net>
  * @since 2015-08-02
  */
-class AddToEntityInstantiatorBehaviorTest extends PHPUnit_Framework_TestCase
+class AddToEntityInstantiatorBehaviorTest extends TestCase
 {
     /** @var string */
     private $className;
@@ -35,7 +39,7 @@ class AddToEntityInstantiatorBehaviorTest extends PHPUnit_Framework_TestCase
     /** @var bool */
     private $useFullyQualifiedName;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         //begin of setting runtime environments
         $fileSystem = vfsStream::setup();
@@ -105,67 +109,67 @@ EOF;
         }
     }
 
-    public function testInstantiatorFileExistsAndContainsExpectedContent()
+    public function testInstantiatorFileExistsAndContainsExpectedContent(): void
     {
         $path = $this->path . DIRECTORY_SEPARATOR . $this->className . '.php';
-        $this->assertTrue(file_exists($path), $path);
+        static::assertTrue(file_exists($path), $path);
 
         require_once ($path);
 
         $content = file_get_contents($path);
 
-        self::assertContains($this->className, $content);
-        self::assertContains($this->connectionMode, $content);
-        self::assertContains($this->connectionName, $content);
-        self::assertContains($this->extends, $content);
-        self::assertContains($this->indention, $content);
-        self::assertContains($this->namespace, $content);
-        self::assertContains($this->prefix, $content);
+        self::assertStringContainsString($this->className, $content);
+        self::assertStringContainsString($this->connectionMode, $content);
+        self::assertStringContainsString($this->connectionName, $content);
+        self::assertStringContainsString($this->extends, $content);
+        self::assertStringContainsString($this->indention, $content);
+        self::assertStringContainsString($this->namespace, $content);
+        self::assertStringContainsString($this->prefix, $content);
     }
 
     /**
      * @depends testInstantiatorFileExistsAndContainsExpectedContent
      */
-    public function testInstantiatorClassExists()
+    public function testInstantiatorClassExists(): void
     {
         $fullQualifiedClassName = $this->namespace . '\\' . $this->className;
-        $this->assertTrue(class_exists($fullQualifiedClassName));
+        static::assertTrue(class_exists($fullQualifiedClassName));
     }
 
     /**
      * @depends testInstantiatorClassExists
      */
-    public function testInstantiatorExtendsStdClass()
+    public function testInstantiatorExtendsStdClass(): void
     {
         $fullQualifiedClassName = $this->namespace . '\\' . $this->className;
         $instantiator           = new $fullQualifiedClassName();
 
-        $this->assertInstanceOf('stdClass', $instantiator);
+        static::assertInstanceOf('stdClass', $instantiator);
     }
 
     /**
      * @depends testInstantiatorClassExists
      */
-    public function testInstantiatorClassHasExpectedMethods()
+    public function testInstantiatorClassHasExpectedMethods(): void
     {
         $fullQualifiedClassName = $this->namespace . '\\' . $this->className;
 
         $methods = get_class_methods($fullQualifiedClassName);
 
-        $this->assertContains('getConnection', $methods);
-        $this->assertContains('createMaximumTableOne', $methods);
-        $this->assertContains('createMaximumTableOneQuery', $methods);
+        static::assertContains('getConnection', $methods);
+        static::assertContains('createMaximumTableOne', $methods);
+        static::assertContains('createMaximumTableOneQuery', $methods);
     }
 
     /**
      * @depends testInstantiatorClassHasExpectedMethods
      */
-    public function testThatMethodsReturningRightInstances()
+    public function testThatMethodsReturningRightInstances(): void
     {
         $fullQualifiedClassName = $this->namespace . '\\' . $this->className;
         $instantiator           = new $fullQualifiedClassName();
 
-        $this->assertTrue(($instantiator->createMaximumTableOne() instanceof MaximumTableOne));
-        $this->assertTrue(($instantiator->createMaximumTableOneQuery() instanceof MaximumTableOneQuery));
+        static::assertTrue(($instantiator->createMaximumTableOne() instanceof MaximumTableOne));
+        static::assertTrue(($instantiator->createMaximumTableOneQuery() instanceof MaximumTableOneQuery));
     }
 }

--- a/test/AddToEntityInstantiatorBehaviorWithMinimumConfigurationTest.php
+++ b/test/AddToEntityInstantiatorBehaviorWithMinimumConfigurationTest.php
@@ -1,12 +1,16 @@
 <?php
+
+declare(strict_types=1);
+
 use Net\Bazzline\Propel\Behavior\EntityInstantiator\Manager;
 use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author stev leibelt <artodeto@bazzline.net>
  * @since 2015-08-02
  */
-class AddToEntityInstantiatorBehaviorWithMinimumConfigurationTest extends PHPUnit_Framework_TestCase
+class AddToEntityInstantiatorBehaviorWithMinimumConfigurationTest extends TestCase
 {
     /** @var string */
     private $className;
@@ -26,7 +30,7 @@ class AddToEntityInstantiatorBehaviorWithMinimumConfigurationTest extends PHPUni
     /** @var string */
     private $prefix;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         //begin of setting runtime environments
         $fileSystem = vfsStream::setup();
@@ -86,65 +90,65 @@ EOF;
         }
     }
 
-    public function testInstantiatorFileExistsAndContainsExpectedContent()
+    public function testInstantiatorFileExistsAndContainsExpectedContent(): void
     {
         $path = $this->path . DIRECTORY_SEPARATOR . $this->className . '.php';
-        $this->assertTrue(file_exists($path), $path);
+        static::assertTrue(file_exists($path), $path);
 
         require_once ($path);
 
         $content = file_get_contents($path);
 
-        self::assertContains($this->className, $content);
-        self::assertContains($this->extends, $content);
-        self::assertContains($this->indention, $content);
-        self::assertContains($this->namespace, $content);
-        self::assertContains($this->prefix, $content);
+        self::assertStringContainsString($this->className, $content);
+        self::assertStringContainsString($this->extends, $content);
+        self::assertStringContainsString($this->indention, $content);
+        self::assertStringContainsString($this->namespace, $content);
+        self::assertStringContainsString($this->prefix, $content);
     }
 
     /**
      * @depends testInstantiatorFileExistsAndContainsExpectedContent
      */
-    public function testInstantiatorClassExists()
+    public function testInstantiatorClassExists(): void
     {
         $fullQualifiedClassName = $this->namespace . '\\' . $this->className;
-        $this->assertTrue(class_exists($fullQualifiedClassName));
+        static::assertTrue(class_exists($fullQualifiedClassName));
     }
 
     /**
      * @depends testInstantiatorClassExists
      */
-    public function testInstantiatorExtendsStdClass()
+    public function testInstantiatorExtendsStdClass(): void
     {
         $fullQualifiedClassName = $this->namespace . '\\' . $this->className;
         $instantiator           = new $fullQualifiedClassName();
 
-        $this->assertInstanceOf('stdClass', $instantiator);
+        static::assertInstanceOf('stdClass', $instantiator);
     }
 
     /**
      * @depends testInstantiatorClassExists
      */
-    public function testInstantiatorClassHasExpectedMethods()
+    public function testInstantiatorClassHasExpectedMethods(): void
     {
         $fullQualifiedClassName = $this->namespace . '\\' . $this->className;
 
         $methods = get_class_methods($fullQualifiedClassName);
 
-        $this->assertContains('getConnection', $methods);
-        $this->assertContains('createMinimumTableOne', $methods);
-        $this->assertContains('createMinimumTableOneQuery', $methods);
+        static::assertContains('getConnection', $methods);
+        static::assertContains('createMinimumTableOne', $methods);
+        static::assertContains('createMinimumTableOneQuery', $methods);
     }
 
     /**
      * @depends testInstantiatorClassHasExpectedMethods
      */
-    public function testThatMethodsReturningRightInstances()
+    public function testThatMethodsReturningRightInstances(): void
     {
         $fullQualifiedClassName = $this->namespace . '\\' . $this->className;
         $instantiator           = new $fullQualifiedClassName();
 
-        $this->assertTrue(($instantiator->createMinimumTableOne() instanceof MinimumTableOne));
-        $this->assertTrue(($instantiator->createMinimumTableOneQuery() instanceof MinimumTableOneQuery));
+        static::assertTrue(($instantiator->createMinimumTableOne() instanceof MinimumTableOne));
+        static::assertTrue(($instantiator->createMinimumTableOneQuery() instanceof MinimumTableOneQuery));
     }
 }

--- a/test/ConfigurationTest.php
+++ b/test/ConfigurationTest.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * @author stev leibelt <artodeto@bazzline.net>
  * @since 2015-09-20
@@ -6,16 +7,17 @@
 namespace Test\Net\Bazzline\Propel\Behavior\EntityInstantiator;
 
 use Net\Bazzline\Propel\Behavior\EntityInstantiator\Configuration;
+use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_TestCase;
 
-class ConfigurationTest extends PHPUnit_Framework_TestCase
+class ConfigurationTest extends TestCase
 {
-    public function testIsNotConfigured()
+    public function testIsNotConfigured(): void
     {
         $configuration = $this->getNewConfiguration();
 
-        $this->assertFalse($configuration->isConfigured());
-        $this->assertTrue($configuration->isNotConfigured());
+        static::assertFalse($configuration->isConfigured());
+        static::assertTrue($configuration->isNotConfigured());
 
         $configuration->configure(
             __CLASS__,
@@ -23,11 +25,11 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
             __DIR__
         );
 
-        $this->assertTrue($configuration->isConfigured());
-        $this->assertFalse($configuration->isNotConfigured());
+        static::assertTrue($configuration->isConfigured());
+        static::assertFalse($configuration->isNotConfigured());
     }
 
-    public function testMinimumConfiguration()
+    public function testMinimumConfiguration(): void
     {
         //begin of dependencies
         $className      = __CLASS__;
@@ -50,14 +52,14 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
         self::assertEquals('null', $configuration->getDefaultConnectionName());
         self::assertEquals($indention, $configuration->getIndention());
         self::assertNull($configuration->getNamespace());
-        self::assertContains($pathToOutput, $configuration->getFilePathToOutput());
+        self::assertStringContainsString($pathToOutput, $configuration->getFilePathToOutput());
         self::assertFalse($configuration->hasExtends());
         self::assertFalse($configuration->hasNamespace());
         self::assertFalse($configuration->useFullyQualifiedNames());
         //end of business logic
     }
 
-    public function testMaximumConfiguration()
+    public function testMaximumConfiguration(): void
     {
         //begin of dependencies
         $className              = __CLASS__;
@@ -90,7 +92,7 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
         self::assertEquals('\'' . $defaultConnectionName . '\'', $configuration->getDefaultConnectionName());
         self::assertEquals($indention, $configuration->getIndention());
         self::assertEquals($namespace, $configuration->getNamespace());
-        self::assertContains($pathToOutput, $configuration->getFilePathToOutput());
+        self::assertStringContainsString($pathToOutput, $configuration->getFilePathToOutput());
         self::assertTrue($configuration->hasExtends());
         self::assertTrue($configuration->hasNamespace());
         self::assertTrue($configuration->useFullyQualifiedNames());

--- a/test/ManagerTest.php
+++ b/test/ManagerTest.php
@@ -1,18 +1,20 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @author stev leibelt <artodeto@bazzline.net>
  * @since 2015-08-31
  */
 namespace Test\Net\Bazzline\Propel\Behavior\EntityInstantiator;
 
-use Mockery;
 use Net\Bazzline\Propel\Behavior\EntityInstantiator\Manager;
-use PHPUnit_Framework_TestCase;
 use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use RuntimeException;
 
-class ManagerTest extends PHPUnit_Framework_TestCase
+class ManagerTest extends TestCase
 {
     /** @var string */
     private $className;
@@ -38,7 +40,7 @@ class ManagerTest extends PHPUnit_Framework_TestCase
     /** @var bool */
     private $useFullyQualifiedName;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->resetGenerator();
 
@@ -52,22 +54,15 @@ class ManagerTest extends PHPUnit_Framework_TestCase
         $this->useFullyQualifiedName    = false;
     }
 
-    protected function tearDown()
+    public function testCallingGenerateBeforeCallingConfigure(): void
     {
-        Mockery::close();
-    }
-
-    /**
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage you have to call configure first
-     */
-    public function testCallingGenerateBeforeCallingConfigure()
-    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('you have to call configure first');
         $manager = $this->getManager();
         $manager->generate();
     }
 
-    public function testGenerateByUsingNamespace()
+    public function testGenerateByUsingNamespace(): void
     {
         $manager = $this->getManager();
 
@@ -88,17 +83,17 @@ class ManagerTest extends PHPUnit_Framework_TestCase
 
         self::assertTrue(file_exists($filePath));
 
-        self::assertContains('class ' . $this->className, $fileContent);
-        self::assertContains('extends ' . $this->extends, $fileContent);
-        self::assertContains($this->indention . 'public function ', $fileContent);
-        self::assertContains('namespace ' . $this->namespace, $fileContent);
-        self::assertContains('use Propel;' , $fileContent);
-        self::assertContains('use PDO;' , $fileContent);
-        self::assertContains('$name = \'' . $this->defaultConnectionName . '\'' , $fileContent);
-        self::assertContains('$mode = ' . $this->defaultConnectionMode , $fileContent);
+        self::assertStringContainsString('class ' . $this->className, $fileContent);
+        self::assertStringContainsString('extends ' . $this->extends, $fileContent);
+        self::assertStringContainsString($this->indention . 'public function ', $fileContent);
+        self::assertStringContainsString('namespace ' . $this->namespace, $fileContent);
+        self::assertStringContainsString('use Propel;' , $fileContent);
+        self::assertStringContainsString('use PDO;' , $fileContent);
+        self::assertStringContainsString('$name = \'' . $this->defaultConnectionName . '\'' , $fileContent);
+        self::assertStringContainsString('$mode = ' . $this->defaultConnectionMode , $fileContent);
     }
 
-    public function testGenerateWithoutUsingNamespace()
+    public function testGenerateWithoutUsingNamespace(): void
     {
         $manager = $this->getManager();
 
@@ -119,14 +114,14 @@ class ManagerTest extends PHPUnit_Framework_TestCase
 
         self::assertTrue(file_exists($filePath));
 
-        self::assertContains('class ' . $this->className, $fileContent);
-        self::assertContains('extends ' . $this->extends, $fileContent);
-        self::assertContains($this->indention . 'public function ', $fileContent);
-        self::assertNotContains('namespace', $fileContent);
-        self::assertNotContains('use Propel;' , $fileContent);
-        self::assertNotContains('use PDO;' , $fileContent);
-        self::assertContains('$name = \'' . $this->defaultConnectionName . '\'' , $fileContent);
-        self::assertContains('$mode = ' . $this->defaultConnectionMode , $fileContent);
+        self::assertStringContainsString('class ' . $this->className, $fileContent);
+        self::assertStringContainsString('extends ' . $this->extends, $fileContent);
+        self::assertStringContainsString($this->indention . 'public function ', $fileContent);
+        self::assertStringNotContainsString('namespace', $fileContent);
+        self::assertStringNotContainsString('use Propel;' , $fileContent);
+        self::assertStringNotContainsString('use PDO;' , $fileContent);
+        self::assertStringContainsString('$name = \'' . $this->defaultConnectionName . '\'' , $fileContent);
+        self::assertStringContainsString('$mode = ' . $this->defaultConnectionMode , $fileContent);
     }
 
     /**

--- a/test/ObjectEntityTest.php
+++ b/test/ObjectEntityTest.php
@@ -1,17 +1,17 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Test\Net\Bazzline\Propel\Behavior\EntityInstantiator;
 
 use Net\Bazzline\Propel\Behavior\EntityInstantiator\ObjectEntity;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author stev leibelt <artodeto@bazzline.net>
  * @since 2015-08-31
  */
-class ObjectEntityTest extends PHPUnit_Framework_TestCase
+class ObjectEntityTest extends TestCase
 {
-    public function testConstructor()
+    public function testConstructor(): void
     {
         $className              = 'bar';
         $databaseName           = 'foobar';
@@ -20,9 +20,9 @@ class ObjectEntityTest extends PHPUnit_Framework_TestCase
 
         $entity = new ObjectEntity($className, $databaseName, $fullQualifiedClassName, $methodNamePrefix);
 
-        $this->assertEquals($className, $entity->className());
-        $this->assertEquals($databaseName, $entity->databaseName());
-        $this->assertEquals($fullQualifiedClassName, $entity->fullQualifiedClassName());
-        $this->assertEquals($methodNamePrefix, $entity->methodNamePrefix());
+        static::assertEquals($className, $entity->className());
+        static::assertEquals($databaseName, $entity->databaseName());
+        static::assertEquals($fullQualifiedClassName, $entity->fullQualifiedClassName());
+        static::assertEquals($methodNamePrefix, $entity->methodNamePrefix());
     }
 }

--- a/test/QueryEntityTest.php
+++ b/test/QueryEntityTest.php
@@ -1,17 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Test\Net\Bazzline\Propel\Behavior\EntityInstantiator;
 
 use Net\Bazzline\Propel\Behavior\EntityInstantiator\QueryEntity;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author stev leibelt <artodeto@bazzline.net>
  * @since 2015-08-31
  */
-class QueryEntityTest extends PHPUnit_Framework_TestCase
+class QueryEntityTest extends TestCase
 {
-    public function testConstructor()
+    public function testConstructor(): void
     {
         $className              = 'bar';
         $databaseName           = 'foobar';
@@ -20,9 +22,9 @@ class QueryEntityTest extends PHPUnit_Framework_TestCase
 
         $entity = new QueryEntity($className, $databaseName, $fullQualifiedClassName, $methodNamePrefix);
 
-        $this->assertEquals($className, $entity->className());
-        $this->assertEquals($databaseName, $entity->databaseName());
-        $this->assertEquals($fullQualifiedClassName, $entity->fullQualifiedClassName());
-        $this->assertEquals($methodNamePrefix, $entity->methodNamePrefix());
+        static::assertEquals($className, $entity->className());
+        static::assertEquals($databaseName, $entity->databaseName());
+        static::assertEquals($fullQualifiedClassName, $entity->fullQualifiedClassName());
+        static::assertEquals($methodNamePrefix, $entity->methodNamePrefix());
     }
 }

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 //taken from: https://github.com/willdurand/StateMachineBehavior/blob/master/tests/bootstrap.php
 require_once __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
to run docker compose:

```
docker-compose up -d
// installation of composer dependencies is performed in the background
docker-compose exec php bash
phpunit
```